### PR TITLE
Corrects schema for "items" array in advertiser_categories

### DIFF
--- a/tap_megaphone/schemas/advertiser_categories.schema.json
+++ b/tap_megaphone/schemas/advertiser_categories.schema.json
@@ -10,40 +10,46 @@
         "null"
       ],
       "items": {
-        "label": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "value": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "children": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "label": {
             "type": [
-              "null",
-              "object"
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "children": {
+            "type": [
+              "array",
+              "null"
             ],
-            "properties": {
-              "label": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "value": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "value": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
               }
             }
           }

--- a/tap_megaphone/schemas/campaign_orders.schema.json
+++ b/tap_megaphone/schemas/campaign_orders.schema.json
@@ -134,6 +134,18 @@
         ]
       }
     },
+    "geoexclusion": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "string"
+        ]
+      }
+    },
     "state": {
       "type": [
         "string",
@@ -190,13 +202,19 @@
           }
       }
     },
+    "priceType": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "promo": {
       "type": [
         "boolean",
         "null"
       ]
     },
-    "trackingURLs": {
+    "deviceTargets": {
       "type": [
         "array",
         "null"
@@ -207,6 +225,44 @@
           "null"
         ]
       }
+    },
+    "frequencyCaps": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "object",
+          "null"
+        ],
+        "properties": {
+            "days": {
+              "type": [
+                "number",
+                "null"
+              ]
+            },
+            "impressions": {
+              "type": [
+                "number",
+                "null"
+              ]
+            }
+          }
+      }
+    },
+    "targetedSegments": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "pacingType": {
+      "type": [
+        "string",
+        "null"
+      ]
     }
   }
 }

--- a/tap_megaphone/schemas/countries.schema.json
+++ b/tap_megaphone/schemas/countries.schema.json
@@ -9,18 +9,24 @@
         "array",
         "null"
       ],
-      "properties": {
-        "label": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "value": {
-          "type": [
-            "string",
-            "null"
-          ]
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     }

--- a/tap_megaphone/schemas/devices.schema.json
+++ b/tap_megaphone/schemas/devices.schema.json
@@ -9,18 +9,24 @@
         "array",
         "null"
       ],
-      "properties": {
-        "label": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "value": {
-          "type": [
-            "string",
-            "null"
-          ]
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     }

--- a/tap_megaphone/schemas/dmas.schema.json
+++ b/tap_megaphone/schemas/dmas.schema.json
@@ -9,18 +9,24 @@
         "array",
         "null"
       ],
-      "properties": {
-        "label": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "value": {
-          "type": [
-            "string",
-            "null"
-          ]
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     }

--- a/tap_megaphone/schemas/iab_advertiser_categories.schema.json
+++ b/tap_megaphone/schemas/iab_advertiser_categories.schema.json
@@ -9,41 +9,47 @@
         "array",
         "null"
       ],
-      "properties": {
-        "label": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "value": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "children": {
-          "type": [
-            "array",
-            "null"
-          ],
-          "items": {
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "label": {
             "type": [
-              "null",
-              "object"
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "children": {
+            "type": [
+              "array",
+              "null"
             ],
-            "properties": {
-              "label": {
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "value": {
-                "type": [
-                  "string",
-                  "null"
-                ]
+            "items": {
+              "type": [
+                "null",
+                "object"
+              ],
+              "properties": {
+                "label": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "value": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
               }
             }
           }

--- a/tap_megaphone/schemas/nielsen_segments.schema.json
+++ b/tap_megaphone/schemas/nielsen_segments.schema.json
@@ -9,18 +9,24 @@
         "array",
         "null"
       ],
-      "properties": {
-        "label": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "value": {
-          "type": [
-            "string",
-            "null"
-          ]
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     }

--- a/tap_megaphone/schemas/organization_tags.schema.json
+++ b/tap_megaphone/schemas/organization_tags.schema.json
@@ -9,18 +9,24 @@
         "array",
         "null"
       ],
-      "properties": {
-        "label": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "value": {
-          "type": [
-            "string",
-            "null"
-          ]
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     }

--- a/tap_megaphone/schemas/promo_orders.schema.json
+++ b/tap_megaphone/schemas/promo_orders.schema.json
@@ -128,18 +128,6 @@
         ]
       }
     },
-    "geoexclusion": {
-      "type": [
-        "array",
-        "null"
-      ],
-      "items": {
-        "type": [
-          "null",
-          "string"
-        ]
-      }
-    },
     "state": {
       "type": [
         "string",
@@ -170,6 +158,18 @@
         "null"
       ]
     },
+    "trackingURLs": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": [
+          "string",
+          "null"
+        ]
+      }
+    },
     "targets": {
       "type": [
         "array",
@@ -181,19 +181,19 @@
           "null"
         ],
         "properties": {
-            "type": {
-              "type": [
-                "string",
-                "null"
-              ]
-            },
-            "id": {
-              "type": [
-                "string",
-                "null"
-              ]
-            }
+          "type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
+        }
       }
     },
     "priceType": {

--- a/tap_megaphone/schemas/regions.schema.json
+++ b/tap_megaphone/schemas/regions.schema.json
@@ -9,18 +9,24 @@
         "array",
         "null"
       ],
-      "properties": {
-        "label": {
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "value": {
-          "type": [
-            "string",
-            "null"
-          ]
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "label": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "value": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         }
       }
     }


### PR DESCRIPTION
For JSONSchema `array` fields with nested properties, you must first declare `"type": "object"` and list the nested fields as `properties` of that object. Previously the `advertiser_categories` listed the properties as top-level keys under `items` and they were just ignored. `target-bigquery` would then throw an error because it didn't have a fully specified schema.